### PR TITLE
readme: read stream has no "finish" event

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ const up = db.createDropboxUploadStream({
   .on('metadata', metadata => console.log('Metadata', metadata))
 
 fs.createReadStream(FILETOUPLOAD).pipe(up)
-  .on('finish', () => console.log('This fires before metadata!'))
+  .on('end', () => console.log('This fires before metadata!'))
 
 ```
 


### PR DESCRIPTION
Changed event name: `finish` -> `end`. 
Read stream uses [end](https://nodejs.org/dist/latest-v9.x/docs/api/stream.html#stream_event_end) for this purpose.