### PR TITLE
Fixed upload: autorename always true

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -8,7 +8,7 @@ const DropboxUploadStream = function(opts = {}) {
   this.chunkSize = opts.chunkSize || 1000 * 1024;
   this.filepath = opts.filepath;
   this.token = opts.token;
-  this.autorename = opts.autorename || true;
+  this.autorename = opts.autorename === undefined ? true : opts.autorename;
   this.session = undefined;
   this.offset = 0;
 }


### PR DESCRIPTION
Hi, thank you for a very useful module `dropbox-stream`. It really helps to use `dropbox api` as streams :). I am working on [file manager for the web](https://cloudcmd.io) and thinking about `dropbox` support.

There is a little bug with `autorename` flag, the thing is, it's always true:

In this expression:
```js
this.autorename = opts.autorename || true; 
```
It is the same as:

```js
false || true;
// always returns true
```

It is better to check for `undefined`, there is default value of `autorename` we can set it when it is `undefined` :):

```js
this.autorename = opts.autorename === undefined ? true : opts.autorename;
```

Otherwise we will use `autorename` value from `opts`.