### PR TITLE
Upload mode

### DIFF
--- a/api.js
+++ b/api.js
@@ -90,7 +90,7 @@ module.exports = function(opts, cb) {
   }
 
   const req = got.stream.post(api[opts.call], {
-    headers: headers
+    headers,
   });
 
   req.on('error', cb);

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ const up = db.createDropboxUploadStream({
     token: TOKEN,
     filepath: '/test/' + path.basename(FILETOUPLOAD),
     chunkSize: 1000 * 1024,
-    autorename: true
+    autorename: true,
+    mode: 'add'
   })
   .on('error', err => console.log(err))
   .on('progress', res => console.log(res))

--- a/upload.js
+++ b/upload.js
@@ -9,6 +9,7 @@ const DropboxUploadStream = function(opts = {}) {
   this.filepath = opts.filepath;
   this.token = opts.token;
   this.autorename = opts.autorename === undefined ? true : opts.autorename;
+  this.mode = opts.mode === undefined ? 'add' : opts.mode;
   this.session = undefined;
   this.offset = 0;
 }
@@ -57,7 +58,8 @@ DropboxUploadStream.prototype.upload = function(cb) {
     data: this.buffer,
     args: {
       path: this.filepath,
-      autorename: this.autorename
+      autorename: this.autorename,
+      mode: this.mode,
     }
   }, (err, res) => {
     if (err) {


### PR DESCRIPTION
Added ability to set [upload](https://www.dropbox.com/developers/documentation/http/documentation#files-upload) `mode`.

>  **mode** _WriteMode_ Selects what to do if the file already exists. The default for this union is add.

This change is backward compatible and gives me ability to `overwrite` existing files while editing with help of streams in a way I do this with regular files in [cloudcmd](https://cloudcmd.io), with help of a `pipe`:

```js
const {createDropboxUploadStream} = require('dropbox-stream');
// express middleware
(req, res) => {
  req.pipe(createDropboxUploadStream({
    token: '',
    filepath: '/hello.txt'
    mode: 'overwrite', // with mode='add' file is never changed
    autorename: false,
  }));
}
```